### PR TITLE
Adds initial integration testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TAG=latest
 IMAGE=tsuru/nginx-operator
 
-.PHONY: test deploy local build push
+.PHONY: test deploy local build push generate
 
 test:
 	go test ./...

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,0 +1,56 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func createNamespace(ns string) error {
+	if out, err := kubectl("create", "namespace", ns); err != nil {
+		if strings.Contains(string(out), "AlreadyExists") {
+			return nil
+		}
+		return fmt.Errorf("failed to create namespace %q: %v - out: %v", ns, err, string(out))
+	}
+	return nil
+}
+
+func deleteNamespace(ns string) error {
+	if _, err := kubectl("delete", "namespace", ns); err != nil {
+		return fmt.Errorf("failed to delete namespace %q: %v", ns, err)
+	}
+	return nil
+}
+
+func apply(file string, ns string) error {
+	if _, err := kubectl("apply", "-f", file, "--namespace", ns); err != nil {
+		return fmt.Errorf("failed to apply %q: %v", file, err)
+	}
+	return nil
+}
+
+func delete(file string, ns string) error {
+	if _, err := kubectl("delete", "-f", file, "--namespace", ns); err != nil {
+		return fmt.Errorf("failed to apply %q: %v", file, err)
+	}
+	return nil
+}
+
+func get(obj runtime.Object, name string) error {
+	out, err := kubectl("get", obj.GetObjectKind().GroupVersionKind().Kind, "-o", "json", name)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(out, obj)
+}
+
+func kubectl(arg ...string) ([]byte, error) {
+	cmd := exec.CommandContext(context.TODO(), "kubectl", arg...)
+	fmt.Printf("Running %v\n", cmd)
+	return cmd.CombinedOutput()
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -1,0 +1,64 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tsuru/nginx-operator/pkg/apis/nginx/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testingNamespace = "nginx-operator-integration"
+
+	testingEnvironment = "NGINX_OPERATOR_INTEGRATION"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(testingEnvironment) == "" {
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+func Test_Operator(t *testing.T) {
+	if err := createNamespace(testingNamespace); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := deleteNamespace(testingNamespace); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	t.Run("simple.yaml", func(t *testing.T) {
+		if err := apply("testdata/simple.yaml", testingNamespace); err != nil {
+			t.Error(err)
+		}
+
+		nginx, err := getReadyNginx("simple", 2, 1)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(nginx.Status.Pods))
+		assert.Equal(t, 1, len(nginx.Status.Services))
+	})
+}
+
+func getReadyNginx(name string, expectedPods int, expectedSvcs int) (*v1alpha1.Nginx, error) {
+	nginx := &v1alpha1.Nginx{TypeMeta: metav1.TypeMeta{Kind: "Nginx"}}
+	timeout := time.After(10 * time.Second)
+	for {
+		if len(nginx.Status.Pods) == expectedPods && len(nginx.Status.Services) == expectedSvcs {
+			return nginx, nil
+		}
+		if err := get(nginx, name); err != nil {
+			return nil, err
+		}
+		select {
+		case <-timeout:
+			return nil, fmt.Errorf("Timeout waiting for nginx status. Last status: %v", nginx.Status)
+		default:
+		}
+	}
+}

--- a/test/testdata/simple.yaml
+++ b/test/testdata/simple.yaml
@@ -1,0 +1,7 @@
+# Single replica nginx deploy
+apiVersion: nginx.tsuru.io/v1alpha1
+kind: Nginx
+metadata:
+  name: simple
+spec:
+  replicas: 2


### PR DESCRIPTION
This PR does a first attempt at providing integration tests
for the operator.

The tests live in test/ directory and only run if the `NGINX_OPERATOR_INTEGRATION`
env is set. 

The suite will create a single namespace to hold all objects created during tests. It expects
that an nginx-operator is running and watching the integration namespace to react for created
nginx objects.

Each test will apply a .yml containing an Nginx definition and will make assertions based on expected
objects to exist and also check that everything is removed after a deletion.

Currently it uses kubectl and does not require to run inside the cluster.

TODO: configure travis to run the integration suite using minikube.