### PR TITLE
Test instance readiness through a command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,307 +2,397 @@
 
 
 [[projects]]
+  digest = "1:315ee4e58738f41b338a701e8acb4e991f6d30737c2ae757d2087a1d28d72810"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
+  pruneopts = "NT"
   revision = "28a4bc8c44b3acbcc482cff0cdf7de29a4688b61"
   version = "v0.35.1"
 
 [[projects]]
+  digest = "1:d8ebbd207f3d3266d4423ce4860c9f3794956306ded6c7ba312ecc69cdfbf04c"
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
+  pruneopts = "NT"
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
   name = "github.com/PuerkitoBio/urlesc"
   packages = ["."]
+  pruneopts = "NT"
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
   branch = "master"
+  digest = "1:c819830f4f5ef85874a90ac3cbcc96cd322c715f5c96fbe4722eacd3dafbaa07"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "NT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:4b8b5811da6970495e04d1f4e98bb89518cc3cfc3b3f456bdb876ed7b6c74049"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:3f718788c59f3ec687bcc963cb6034a132327387784c8c04392abaaea9ad7498"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
-    "log"
+    "log",
   ]
+  pruneopts = "NT"
   revision = "e37671aced663c8d3a395bd301857e26dcf4340c"
   version = "v2.8.1"
 
 [[projects]]
+  digest = "1:81466b4218bf6adddac2572a30ac733a9255919bc2f470b4827a317bd4ee1756"
   name = "github.com/ghodss/yaml"
   packages = ["."]
+  pruneopts = "NT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:d421af4c4fe51d399667d573982d663fe1fa67020a88d3ae43466ebfe8e2b5c9"
   name = "github.com/go-logr/logr"
   packages = ["."]
+  pruneopts = "NT"
   revision = "9fb12b3b21c5415d16ac18dc5cd42c1cfdd40c4e"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:340497a512995aa69c0add901d79a2096b3449d35a44a6f1f1115091a9f8c687"
   name = "github.com/go-logr/zapr"
   packages = ["."]
-  revision = "7536572e8d55209135cd5e7ccf7fce43dca217ab"
-  version = "v0.1.0"
+  pruneopts = "NT"
+  revision = "03f06a783fbb7dfaf3f629c7825480e43a7105e6"
+  version = "v0.1.1"
 
 [[projects]]
+  digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
+  pruneopts = "NT"
   revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
   version = "v0.18.0"
 
 [[projects]]
+  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
+  pruneopts = "NT"
   revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
   version = "v0.18.0"
 
 [[projects]]
+  digest = "1:4da4ea0a664ba528965683d350f602d0f11464e6bb2e17aad0914723bc25d163"
   name = "github.com/go-openapi/spec"
   packages = ["."]
+  pruneopts = "NT"
   revision = "5b6cdde3200976e3ecceb2868706ee39b6aff3e4"
   version = "v0.18.0"
 
 [[projects]]
+  digest = "1:dc0f590770e5a6c70ea086232324f7b7dc4857c60eca63ab8ff78e0a5cfcdbf3"
   name = "github.com/go-openapi/swag"
   packages = ["."]
+  pruneopts = "NT"
   revision = "1d29f06aebd59ccdf11ae04aa0334ded96e2d909"
   version = "v0.18.0"
 
 [[projects]]
+  digest = "1:932970e69f16e127aa0653b8263ae588cd127fa53273e19ba44332902c9826f2"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
-    "sortkeys"
+    "sortkeys",
   ]
+  pruneopts = "NT"
   revision = "4cbf7e384e768b4e01799441fdf2a706a5635ae7"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:e2b86e41f3d669fc36b50d31d32d22c8ac656c75aa5ea89717ce7177e134ff2a"
   name = "github.com/golang/glog"
   packages = ["."]
+  pruneopts = "NT"
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
+  digest = "1:aaedc94233e56ed57cdb04e3abfacc85c90c14082b62e3cdbe8ea72fc06ee035"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = "NT"
   revision = "c65c006176ff7ff98bb916961c7abbc6b0afc0aa"
 
 [[projects]]
+  digest = "1:d7cb4458ea8782e6efacd8f4940796ec559c90833509c436f40c4085b98156dd"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "NT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:05f95ffdfcf651bdb0f05b40b69e7f5663047f8da75c72d58728acb59b5cc107"
   name = "github.com/google/btree"
   packages = ["."]
+  pruneopts = "NT"
   revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
 
 [[projects]]
   branch = "master"
+  digest = "1:52c5834e2bebac9030c97cc0798ac11c3aa8a39f098aeb419f142533da6cd3cc"
   name = "github.com/google/gofuzz"
   packages = ["."]
+  pruneopts = "NT"
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:56a1f3949ebb7fa22fa6b4e4ac0fe0f77cc4faee5b57413e6fa9199a8458faf1"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = "NT"
   revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:289332c13b80edfefc88397cce5266c16845dcf204fa2f6ac7e464ee4c7f6e96"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
     "compiler",
-    "extensions"
+    "extensions",
   ]
+  pruneopts = "NT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:97972f03fbf34ec4247ddc78ddb681389c468c020492aa32b109744a54fc0c14"
   name = "github.com/gregjones/httpcache"
   packages = [
     ".",
-    "diskcache"
+    "diskcache",
   ]
+  pruneopts = "NT"
   revision = "c63ab54fda8f77302f8d414e19933f2b6026a089"
 
 [[projects]]
+  digest = "1:b42cde0e1f3c816dd57f57f7bbcf05ca40263ad96f168714c130c611fc0856a6"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
-    "simplelru"
+    "simplelru",
   ]
+  pruneopts = "NT"
   revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:aaa38889f11896ee3644d77e17dc7764cc47f5f3d3b488268df2af2b52541c5f"
   name = "github.com/imdario/mergo"
   packages = ["."]
+  pruneopts = "NT"
   revision = "7c29201646fa3de8506f701213473dd407f19646"
   version = "v0.3.7"
 
 [[projects]]
+  digest = "1:1d39c063244ad17c4b18e8da1551163b6ffb52bd1640a49a8ec5c3b7bf4dbd5d"
   name = "github.com/json-iterator/go"
   packages = ["."]
+  pruneopts = "NT"
   revision = "1624edc4454b8682399def8740d46db5e4362ba4"
   version = "v1.1.5"
 
 [[projects]]
   branch = "master"
+  digest = "1:7d9fcac7f1228470c4ea0ee31cdfb662a758c44df691e39b3e76c11d3e12ba8f"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = "NT"
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
   branch = "master"
+  digest = "1:0e9bfc47ab9941ecc3344e580baca5deb4091177e84dd9773b48b38ec26b93d5"
   name = "github.com/mattbaird/jsonpatch"
   packages = ["."]
+  pruneopts = "NT"
   revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
 
 [[projects]]
+  digest = "1:ea1db000388d88b31db7531c83016bef0d6db0d908a07794bfc36aca16fbf935"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "NT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
+  pruneopts = "NT"
   revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
   version = "1.0.3"
 
 [[projects]]
+  digest = "1:c6aca19413b13dc59c220ad7430329e2ec454cc310bc6d8de2c7e2b93c18a0f6"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
+  pruneopts = "NT"
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:2f054221b7680f682bdd523c02550f6520e13ee6bda75ce17bd72caa33af93a8"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
     "pkg/k8sutil",
     "pkg/leader",
-    "version"
+    "version",
   ]
+  pruneopts = "NT"
   revision = "3c97587d829ff6d54b78ee2f7b09cfe3454f64d1"
 
 [[projects]]
+  digest = "1:93b1d84c5fa6d1ea52f4114c37714cddd84d5b78f151b62bb101128dd51399bf"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "NT"
   revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
   version = "v1.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:bf2ac97824a7221eb16b096aecc1c390d4c8a4e49524386aaa2e2dd215cbfb31"
   name = "github.com/petar/GoLLRB"
   packages = ["llrb"]
+  pruneopts = "NT"
   revision = "53be0d36a84c2a886ca057d34b6aa4468df9ccb4"
 
 [[projects]]
+  digest = "1:e4e9e026b8e4c5630205cd0208efb491b40ad40552e57f7a646bb8a46896077b"
   name = "github.com/peterbourgon/diskv"
   packages = ["."]
+  pruneopts = "NT"
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ec2a29e3bd141038ae5c3d3a4f57db0c341fcc1d98055a607aedd683aed124ee"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
     "prometheus/internal",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "NT"
   revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
   version = "v0.9.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:c2cc5049e927e2749c0d5163c9f8d924880d83e84befa732b9aad0b6be227bed"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "NT"
   revision = "56726106282f1985ea77d5305743db7231b0c0a8"
 
 [[projects]]
+  digest = "1:8e4954d40c6b7c6e3dd8277127cb6b66f9f20c0a3b18ee6f40d763c0e64ec48e"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "NT"
   revision = "2998b132700a7d019ff618c06a234b47c1f3f681"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:42e89ce7daa7d2e08a4dc30943c359ba47c7ba93de7f6a41b974522fe02cf172"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "NT"
   revision = "bf6a532e95b1f7a62adf0ab5050a5bb2237ad2f4"
 
 [[projects]]
+  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:8e8fc2cb42cfa0a18fda0c9c4034092faa7aac773da5efdde8828eb4b96c001d"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
+  pruneopts = "NT"
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:22f696cee54865fb8e9ff91df7b633f6b8f22037a8015253c6b6a71ca82219c7"
   name = "go.uber.org/atomic"
   packages = ["."]
+  pruneopts = "NT"
   revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:58ca93bdf81bac106ded02226b5395a0595d5346cdc4caa8d9c1f3a5f8f9976e"
   name = "go.uber.org/multierr"
   packages = ["."]
+  pruneopts = "NT"
   revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:572fa4496563920f3e3107a2294cf2621d6cc4ffd03403fb6397b1bab9fa082a"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -310,19 +400,23 @@
     "internal/bufferpool",
     "internal/color",
     "internal/exit",
-    "zapcore"
+    "zapcore",
   ]
+  pruneopts = "NT"
   revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
   version = "v1.9.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:aa67eeb004ecca3853c940202a25687f00d8109576edd137fdf8b4f9d2cb8fd2"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "NT"
   revision = "057139ce5d2bdbe6fe73c53679e24e9cf007f637"
 
 [[projects]]
   branch = "master"
+  digest = "1:122c84e1426c98cac9e77db3ff47e41254e6cd4c9368e0786da5b01f5bc0635d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -330,32 +424,38 @@
     "http/httpguts",
     "http2",
     "http2/hpack",
-    "idna"
+    "idna",
   ]
+  pruneopts = "NT"
   revision = "ed066c81e75eba56dd9bd2139ade88125b855585"
 
 [[projects]]
   branch = "master"
+  digest = "1:9a9a8b8635685e9e4ff68c80bebf00726f5019fb41da508a56df54e6e7277eeb"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "google",
     "internal",
     "jws",
-    "jwt"
+    "jwt",
   ]
+  pruneopts = "NT"
   revision = "5dab4167f31cbd76b407f1486c86b40748bc5073"
 
 [[projects]]
   branch = "master"
+  digest = "1:64e1913e5c2127689d73a8e67779478bbaff04e601fb38d910668972c597353a"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "NT"
   revision = "b90733256f2e882e81d52f9126de08df5615afd9"
 
 [[projects]]
+  digest = "1:8c74f97396ed63cc2ef04ebb5fc37bb032871b8fd890a25991ed40974b00cd2a"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -372,19 +472,23 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
-    "width"
+    "width",
   ]
+  pruneopts = "NT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "NT"
   revision = "85acf8d2951cb2a3bde7632f9ff273ef0379bcbd"
 
 [[projects]]
   branch = "master"
+  digest = "1:addf35f982797093ffb7dd172f13d936ec7a83c3bc2e3fe65aede710719ee1f8"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -398,11 +502,13 @@
     "internal/fastwalk",
     "internal/gopathwalk",
     "internal/module",
-    "internal/semver"
+    "internal/semver",
   ]
+  pruneopts = "NT"
   revision = "78ee07aa9465da43bde6d5044c687571ab4362d6"
 
 [[projects]]
+  digest = "1:902ffa11f1d8c19c12b05cabffe69e1a16608ad03a8899ebcb9c6bde295660ae"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -414,24 +520,30 @@
     "internal/modules",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "NT"
   revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
+  pruneopts = "NT"
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:18108594151654e9e696b27b181b953f9a90b16bf14d253dd1b397b025a1487f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "NT"
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
 
 [[projects]]
+  digest = "1:b3f8152a68d73095a40fdcf329a93fc42e8eadb3305171df23fdb6b4e41a6417"
   name = "k8s.io/api"
   packages = [
     "admission/v1beta1",
@@ -465,11 +577,13 @@
     "settings/v1alpha1",
     "storage/v1",
     "storage/v1alpha1",
-    "storage/v1beta1"
+    "storage/v1beta1",
   ]
+  pruneopts = "NT"
   revision = "b503174bad5991eb66f18247f52e41c3258f6348"
 
 [[projects]]
+  digest = "1:868de7cbaa0ecde6dc231c1529a10ae01bb05916095c0c992186e2a5cac57e79"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -514,11 +628,13 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/reflect"
+    "third_party/forked/golang/reflect",
   ]
+  pruneopts = "NT"
   revision = "eddba98df674a16931d2d4ba75edc3a389bf633a"
 
 [[projects]]
+  digest = "1:00089f60de414edb1a51e63efde2480ce87c95d2cb3536ea240afe483905d736"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -565,6 +681,7 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "testing",
     "third_party/forked/golang/template",
     "tools/auth",
     "tools/cache",
@@ -587,11 +704,13 @@
     "util/integer",
     "util/jsonpath",
     "util/retry",
-    "util/workqueue"
+    "util/workqueue",
   ]
+  pruneopts = "NT"
   revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
 
 [[projects]]
+  digest = "1:4e2addcdbe0330f43800c1fcb905fc7a21b86415dfcca619e5c606c87257af1b"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/client-gen",
@@ -617,12 +736,14 @@
     "cmd/lister-gen/generators",
     "cmd/openapi-gen",
     "cmd/openapi-gen/args",
-    "pkg/util"
+    "pkg/util",
   ]
+  pruneopts = "T"
   revision = "3dcf91f64f638563e5106f21f50c31fa361c918d"
 
 [[projects]]
   branch = "master"
+  digest = "1:4d52082d1d9ea18e04c8b859f6696f1ca42849d68257e5b84812f8067694a2e6"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -632,18 +753,22 @@
     "generator",
     "namer",
     "parser",
-    "types"
+    "types",
   ]
+  pruneopts = "NT"
   revision = "f8a0810f38afb8478882b3835a615aebfda39afa"
 
 [[projects]]
+  digest = "1:f3b42f307c7f49a1a7276c48d4b910db76e003220e88797f7acd41e3a9277ddf"
   name = "k8s.io/klog"
   packages = ["."]
+  pruneopts = "NT"
   revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
   version = "v0.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:653cd4cf804493513d5ec945e687639e5fe9a1f7adbcf2db5cd21da31a96674e"
   name = "k8s.io/kube-openapi"
   packages = [
     "cmd/openapi-gen/args",
@@ -651,11 +776,13 @@
     "pkg/generators",
     "pkg/generators/rules",
     "pkg/util/proto",
-    "pkg/util/sets"
+    "pkg/util/sets",
   ]
+  pruneopts = "NT"
   revision = "ced9eb3070a5f1c548ef46e8dfe2a97c208d9f03"
 
 [[projects]]
+  digest = "1:e03ddaf9f31bccbbb8c33eabad2c85025a95ca98905649fd744e0a54c630a064"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -663,6 +790,7 @@
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller",
     "pkg/event",
     "pkg/handler",
@@ -684,14 +812,50 @@
     "pkg/source/internal",
     "pkg/webhook/admission",
     "pkg/webhook/admission/types",
-    "pkg/webhook/types"
+    "pkg/webhook/types",
   ]
+  pruneopts = "NT"
   revision = "c63ebda0bf4be5f0a8abd4003e4ea546032545ba"
   version = "v0.1.8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1528d50177c3b34cfe4a983b11d105b092dbc1dfc2a05f1d55a9e0a6a3009a67"
+  input-imports = [
+    "github.com/operator-framework/operator-sdk/pkg/leader",
+    "github.com/operator-framework/operator-sdk/version",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+    "k8s.io/api/apps/v1",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/labels",
+    "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/intstr",
+    "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+    "k8s.io/code-generator/cmd/client-gen",
+    "k8s.io/code-generator/cmd/conversion-gen",
+    "k8s.io/code-generator/cmd/deepcopy-gen",
+    "k8s.io/code-generator/cmd/defaulter-gen",
+    "k8s.io/code-generator/cmd/informer-gen",
+    "k8s.io/code-generator/cmd/lister-gen",
+    "k8s.io/code-generator/cmd/openapi-gen",
+    "k8s.io/gengo/args",
+    "sigs.k8s.io/controller-runtime/pkg/client",
+    "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
+    "sigs.k8s.io/controller-runtime/pkg/controller",
+    "sigs.k8s.io/controller-runtime/pkg/handler",
+    "sigs.k8s.io/controller-runtime/pkg/manager",
+    "sigs.k8s.io/controller-runtime/pkg/reconcile",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/log",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/scheme",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
+    "sigs.k8s.io/controller-runtime/pkg/source",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/examples/with-configmap-healthcheck.yaml
+++ b/examples/with-configmap-healthcheck.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: healthcheckconf
+data:
+  healthcheck.sh: |
+    #!/bin/bash
+    curl -sq localhost:80
+---
+apiVersion: nginx.tsuru.io/v1alpha1
+kind: Nginx
+metadata:
+  name: nginx-configmap-hc
+spec:
+  image: tsuru/nginx-tsuru:1.16.0
+  replicas: 1
+  healthcheck:
+    kind: ConfigMap
+    name: healthcheckconf

--- a/examples/with-inline-healthcheck.yaml
+++ b/examples/with-inline-healthcheck.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   image: tsuru/nginx-tsuru:1.16.0
   healthcheck:
-    name: nginx-inline-hc-2
+    name: nginx-inline-hc
     kind: Inline
     value: |
       #!/bin/bash
-      curl -sq localhost:8080
+      curl -sq localhost:80

--- a/examples/with-inline-healthcheck.yaml
+++ b/examples/with-inline-healthcheck.yaml
@@ -1,0 +1,12 @@
+apiVersion: nginx.tsuru.io/v1alpha1
+kind: Nginx
+metadata:
+  name: nginx-inline-hc
+spec:
+  image: tsuru/nginx-tsuru:1.16.0
+  healthcheck:
+    name: nginx-inline-hc-2
+    kind: Inline
+    value: |
+      #!/bin/bash
+      curl -sq localhost:8080

--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -30,12 +30,7 @@ type NginxSpec struct {
 	// These additional files will be mounted on `/etc/nginx/extra_files`.
 	// +optional
 	ExtraFiles *FilesRef `json:"extraFiles,omitempty"`
-	// HealthcheckPath defines the endpoint used to check whether instance is
-	// working or not.
-	// +optional
-	HealthcheckPath string `json:"healthcheckPath,omitempty"`
-	// Reference to a script to check pods readiness
-	// working or not.
+	// Reference to a script to check pods readiness.
 	// +optional
 	Healthcheck *ConfigRef `json:healthcheck,omitempty`
 }

--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -30,7 +30,7 @@ type NginxSpec struct {
 	// These additional files will be mounted on `/etc/nginx/extra_files`.
 	// +optional
 	ExtraFiles *FilesRef `json:"extraFiles,omitempty"`
-	// Reference to a script to check pods readiness.
+	// Healthcheck references to a script to check pods readiness.
 	// +optional
 	Healthcheck *ConfigRef `json:"healthcheck,omitempty"`
 }

--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -34,6 +34,10 @@ type NginxSpec struct {
 	// working or not.
 	// +optional
 	HealthcheckPath string `json:"healthcheckPath,omitempty"`
+	// Reference to a script to check pods readiness
+	// working or not.
+	// +optional
+	Healthcheck *ConfigRef `json:healthcheck,omitempty`
 }
 
 type NginxPodTemplateSpec struct {

--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -32,7 +32,7 @@ type NginxSpec struct {
 	ExtraFiles *FilesRef `json:"extraFiles,omitempty"`
 	// Reference to a script to check pods readiness.
 	// +optional
-	Healthcheck *ConfigRef `json:healthcheck,omitempty`
+	Healthcheck *ConfigRef `json:"healthcheck,omitempty"`
 }
 
 type NginxPodTemplateSpec struct {

--- a/pkg/apis/nginx/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/nginx/v1alpha1/zz_generated.deepcopy.go
@@ -190,6 +190,11 @@ func (in *NginxSpec) DeepCopyInto(out *NginxSpec) {
 		*out = new(FilesRef)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Healthcheck != nil {
+		in, out := &in.Healthcheck, &out.Healthcheck
+		*out = new(ConfigRef)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -223,10 +223,10 @@ func setupNginxConf(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {
 
 	configMapName := "nginx-config"
 
-	SetupMounts(conf, dep, configMapName)
+	setupMounts(conf, dep, configMapName)
 }
 
-func SetupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment, configMapName string) {
+func setupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment, configMapName string) {
 	dep.Spec.Template.Spec.Containers[0].VolumeMounts = append(dep.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      configMapName,
 		MountPath: fmt.Sprintf("%s/%s", configMountPath, configFileName),

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -221,19 +221,21 @@ func setupNginxConf(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {
 		return
 	}
 
-	SetupMounts(conf, dep)
+	configMapName := "nginx-config"
+
+	SetupMounts(conf, dep, configMapName)
 }
 
-func SetupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {
+func SetupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment, configMapName string) {
 	dep.Spec.Template.Spec.Containers[0].VolumeMounts = append(dep.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-		Name:      "nginx-config",
+		Name:      configMapName,
 		MountPath: fmt.Sprintf("%s/%s", configMountPath, configFileName),
 		SubPath:   configFileName,
 	})
 	switch conf.Kind {
 	case v1alpha1.ConfigKindConfigMap:
 		dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: "nginx-config",
+			Name: configMapName,
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -103,7 +103,7 @@ func NewDeployment(n *v1alpha1.Nginx) (*appv1.Deployment, error) {
 			},
 		},
 	}
-	setupConfig(n.Spec.Config, &deployment)
+	setupNginxConf(n.Spec.Config, &deployment)
 	setupTLS(n.Spec.Certificates, &deployment)
 	setupExtraFiles(n.Spec.ExtraFiles, &deployment)
 
@@ -216,10 +216,15 @@ func SetNginxSpec(o *metav1.ObjectMeta, spec v1alpha1.NginxSpec) error {
 	return nil
 }
 
-func setupConfig(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {
+func setupNginxConf(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {
 	if conf == nil {
 		return
 	}
+
+	SetupMounts(conf, dep)
+}
+
+func SetupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {
 	dep.Spec.Template.Spec.Containers[0].VolumeMounts = append(dep.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      "nginx-config",
 		MountPath: fmt.Sprintf("%s/%s", configMountPath, configFileName),

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -256,12 +256,12 @@ func setupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment, configMapName 
 		}
 		dep.Spec.Template.Annotations[conf.Name] = conf.Value
 		dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: "nginx-config",
+			Name: configMapName,
 			VolumeSource: corev1.VolumeSource{
 				DownwardAPI: &corev1.DownwardAPIVolumeSource{
 					Items: []corev1.DownwardAPIVolumeFile{
 						{
-							Path: "nginx.conf",
+							Path: fileName,
 							FieldRef: &corev1.ObjectFieldSelector{
 								FieldPath: fmt.Sprintf("metadata.annotations['%s']", conf.Name),
 							},

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 
 	"github.com/tsuru/nginx-operator/pkg/apis/nginx/v1alpha1"
@@ -222,16 +223,20 @@ func setupNginxConf(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {
 	}
 
 	configMapName := "nginx-config"
+	volumeMountPath := fmt.Sprintf("%s/%s", configMountPath, configFileName)
 
-	setupMounts(conf, dep, configMapName)
+	setupMounts(conf, dep, configMapName, volumeMountPath)
 }
 
-func setupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment, configMapName string) {
+func setupMounts(conf *v1alpha1.ConfigRef, dep *appv1.Deployment, configMapName string, volumeMountPath string) {
+	_, fileName := filepath.Split(volumeMountPath)
+
 	dep.Spec.Template.Spec.Containers[0].VolumeMounts = append(dep.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
 		Name:      configMapName,
-		MountPath: fmt.Sprintf("%s/%s", configMountPath, configFileName),
-		SubPath:   configFileName,
+		MountPath: volumeMountPath,
+		SubPath:   fileName,
 	})
+
 	switch conf.Kind {
 	case v1alpha1.ConfigKindConfigMap:
 		dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, corev1.Volume{

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -31,6 +31,12 @@ const (
 	// Default configuration filename of nginx
 	configFileName = "nginx.conf"
 
+	// Mount path where healthcheck.sh will be placed
+	healthcheckScriptMountPath = "/usr/local/bin"
+
+	// Default healthcheck script filename
+	healthcheckScriptFileName = "healthcheck.sh"
+
 	// Mount path where certificate and key pair will be placed
 	certMountPath = configMountPath + "/certs"
 

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -158,11 +158,13 @@ func Test_NewDeployment(t *testing.T) {
 						SubPath:   "nginx.conf",
 					},
 				}
+				mode := int32(0644)
 				d.Spec.Template.Spec.Volumes = []corev1.Volume{
 					{
 						Name: "nginx-config",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
+								DefaultMode: &mode,
 								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "config-map-xpto",
 								},
@@ -194,6 +196,7 @@ func Test_NewDeployment(t *testing.T) {
 				d.Spec.Template.Annotations = map[string]string{
 					"config-inline": "server {}",
 				}
+				mode := int32(0644)
 				d.Spec.Template.Spec.Volumes = []corev1.Volume{
 					{
 						Name: "nginx-config",
@@ -202,6 +205,7 @@ func Test_NewDeployment(t *testing.T) {
 								Items: []corev1.DownwardAPIVolumeFile{
 									{
 										Path: "nginx.conf",
+										Mode: &mode,
 										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "metadata.annotations['config-inline']",
 										},
@@ -231,11 +235,13 @@ func Test_NewDeployment(t *testing.T) {
 						SubPath:   "healthcheck.sh",
 					},
 				}
+				mode := int32(0744)
 				d.Spec.Template.Spec.Volumes = []corev1.Volume{
 					{
 						Name: "healthcheck-script",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
+								DefaultMode: &mode,
 								LocalObjectReference: corev1.LocalObjectReference{
 									Name: "config-map-xpto",
 								},
@@ -274,6 +280,7 @@ func Test_NewDeployment(t *testing.T) {
 				d.Spec.Template.Annotations = map[string]string{
 					"healthcheck-inline": "curl localhost:8080",
 				}
+				mode := int32(0744)
 				d.Spec.Template.Spec.Volumes = []corev1.Volume{
 					{
 						Name: "healthcheck-script",
@@ -282,6 +289,7 @@ func Test_NewDeployment(t *testing.T) {
 								Items: []corev1.DownwardAPIVolumeFile{
 									{
 										Path: "healthcheck.sh",
+										Mode: &mode,
 										FieldRef: &corev1.ObjectFieldSelector{
 											FieldPath: "metadata.annotations['healthcheck-inline']",
 										},


### PR DESCRIPTION
When using the [HTTPGetAction](https://godoc.org/k8s.io/api/core/v1#HTTPGetAction) on [ReadinessProbe](https://godoc.org/k8s.io/api/core/v1#Container.ReadinessProbe), the probe will be made on a single route. In order to test multiple interfaces (e.g HTTP or HTTPS ), we must change the `ReadinessProbe` handler to [ExecAction](https://godoc.org/k8s.io/api/core/v1#ExecAction). This handler will run a command provided by the user.

Like the `nginx.conf`, the user can configure the command Inline or with a `ConfigMap`.

Some examples:

### Using a ConfigMap

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: healthcheckconf
data:
  healthcheck.sh: |
    #!/bin/bash
    curl -sq localhost:80
---
apiVersion: nginx.tsuru.io/v1alpha1
kind: Nginx
metadata:
  name: nginx-configmap-hc
spec:
  # Image must have all binaries used on the script.
  image: tsuru/nginx-tsuru:1.16.0
  replicas: 1
  healthcheck:
    kind: ConfigMap
    name: healthcheckconf
```

### Using Inline configuration

```yaml
apiVersion: nginx.tsuru.io/v1alpha1
kind: Nginx
metadata:
  name: nginx-inline-hc
spec:
  # Image must have all binaries used on the script.
  image: tsuru/nginx-tsuru:1.16.0
  healthcheck:
    name: nginx-inline-hc
    kind: Inline
    value: |
      #!/bin/bash
      curl -sq localhost:80
```