### PR TITLE
Add support to HostNetwork

### DIFF
--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -70,6 +70,9 @@ type NginxPodTemplateSpec struct {
 	// Labels are custom labels to be added into Pod.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+	//HostNetwork enabled causes the pod to use the host's network namespace.
+	// +optional
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 // NginxStatus defines the observed state of Nginx

--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -66,7 +66,7 @@ type NginxPodTemplateSpec struct {
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 	// Annotations are custom annotations to be set into Pod.
 	// +optional
-	Annotations map[string]string `json:"annotations,omitmepty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// Labels are custom labels to be added into Pod.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -26,11 +26,13 @@ const (
 	defaultNginxImage = "nginx:latest"
 
 	// Default port names used by the nginx container and the ClusterIP service
-	defaultHTTPPort     = int32(8080)
-	defaultHTTPPortName = "http"
+	defaultHTTPPort            = int32(8080)
+	defaultHTTPHostNetworkPort = int32(80)
+	defaultHTTPPortName        = "http"
 
-	defaultHTTPSPort     = int32(8443)
-	defaultHTTPSPortName = "https"
+	defaultHTTPSPort            = int32(8443)
+	defaultHTTPSHostNetworkPort = int32(443)
+	defaultHTTPSPortName        = "https"
 
 	// Path and port to the healthcheck service
 	healthcheckPort        = 59999
@@ -108,21 +110,9 @@ func NewDeployment(n *v1alpha1.Nginx) (*appv1.Deployment, error) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:    "nginx",
-							Image:   n.Spec.Image,
-							Command: nginxEntrypoint,
-							Ports: []corev1.ContainerPort{
-								{
-									Name:          defaultHTTPPortName,
-									ContainerPort: defaultHTTPPort,
-									Protocol:      corev1.ProtocolTCP,
-								},
-								{
-									Name:          defaultHTTPSPortName,
-									ContainerPort: defaultHTTPSPort,
-									Protocol:      corev1.ProtocolTCP,
-								},
-							},
+							Name:      "nginx",
+							Image:     n.Spec.Image,
+							Command:   nginxEntrypoint,
 							Resources: n.Spec.Resources,
 							ReadinessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
@@ -147,11 +137,13 @@ func NewDeployment(n *v1alpha1.Nginx) (*appv1.Deployment, error) {
 							Resources: healthcheckResources,
 						},
 					},
-					Affinity: n.Spec.PodTemplate.Affinity,
+					Affinity:    n.Spec.PodTemplate.Affinity,
+					HostNetwork: n.Spec.PodTemplate.HostNetwork,
 				},
 			},
 		},
 	}
+	setupPorts(n.Spec.PodTemplate, &deployment)
 	setupConfig(n.Spec.Config, &deployment)
 	setupTLS(n.Spec.Certificates, &deployment)
 	setupExtraFiles(n.Spec.ExtraFiles, &deployment)
@@ -287,6 +279,27 @@ func buildHealthcheckPath(spec v1alpha1.NginxSpec) string {
 	}
 
 	return fmt.Sprintf("%s?%s", healthcheckPath, query.Encode())
+}
+
+func setupPorts(podSpec v1alpha1.NginxPodTemplateSpec, dep *appv1.Deployment) {
+	httpPort := defaultHTTPPort
+	httpsPort := defaultHTTPSPort
+	if podSpec.HostNetwork {
+		httpPort = defaultHTTPHostNetworkPort
+		httpsPort = defaultHTTPSHostNetworkPort
+	}
+	dep.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+		{
+			Name:          defaultHTTPPortName,
+			ContainerPort: httpPort,
+			Protocol:      corev1.ProtocolTCP,
+		},
+		{
+			Name:          defaultHTTPSPortName,
+			ContainerPort: httpsPort,
+			Protocol:      corev1.ProtocolTCP,
+		},
+	}
 }
 
 func setupConfig(conf *v1alpha1.ConfigRef, dep *appv1.Deployment) {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -20,8 +20,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var httpHealthcheckQuery = "url=http%3A%2F%2Flocalhost%3A8080"
-var httpsHealthcheckQuery = "url=http%3A%2F%2Flocalhost%3A8080&url=https%3A%2F%2Flocalhost%3A8443"
+var (
+	httpHealthcheckQuery             = "url=http%3A%2F%2Flocalhost%3A8080"
+	httpHostNetworkHealthcheckQuery  = "url=http%3A%2F%2Flocalhost%3A80"
+	httpsHealthcheckQuery            = "url=http%3A%2F%2Flocalhost%3A8080&url=https%3A%2F%2Flocalhost%3A8443"
+	httpsHostNetworkHealthcheckQuery = "url=http%3A%2F%2Flocalhost%3A80&url=https%3A%2F%2Flocalhost%3A443"
+)
 
 func baseNginx() v1alpha1.Nginx {
 	return v1alpha1.Nginx{
@@ -475,6 +479,75 @@ func Test_NewDeployment(t *testing.T) {
 						Name:          defaultHTTPSPortName,
 						ContainerPort: defaultHTTPSHostNetworkPort,
 						Protocol:      corev1.ProtocolTCP,
+					},
+				}
+				d.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/healthcheck?" + httpHostNetworkHealthcheckQuery,
+							Port:   intstr.FromInt(healthcheckPort),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+				}
+				return d
+			},
+		},
+		{
+			name: "with-tls-and-host-network",
+			nginxFn: func(n v1alpha1.Nginx) v1alpha1.Nginx {
+				n.Spec.PodTemplate.HostNetwork = true
+				n.Spec.Certificates = &v1alpha1.TLSSecret{
+					SecretName: "my-secret",
+					Items: []v1alpha1.TLSSecretItem{
+						{
+							CertificateField: "cert-field",
+							CertificatePath:  "cert-path",
+							KeyField:         "key-field",
+							KeyPath:          "key-path",
+						},
+					},
+				}
+				return n
+			},
+			deployFn: func(d appv1.Deployment) appv1.Deployment {
+				d.Spec.Template.Spec.HostNetwork = true
+				d.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+					{
+						Name:          defaultHTTPPortName,
+						ContainerPort: defaultHTTPHostNetworkPort,
+						Protocol:      corev1.ProtocolTCP,
+					},
+					{
+						Name:          defaultHTTPSPortName,
+						ContainerPort: defaultHTTPSHostNetworkPort,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				}
+				d.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/healthcheck?" + httpsHostNetworkHealthcheckQuery,
+							Port:   intstr.FromInt(healthcheckPort),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+				}
+				d.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
+					{Name: "nginx-certs", MountPath: "/etc/nginx/certs"},
+				}
+				d.Spec.Template.Spec.Volumes = []corev1.Volume{
+					{
+						Name: "nginx-certs",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: "my-secret",
+								Items: []corev1.KeyToPath{
+									{Key: "cert-field", Path: "cert-path"},
+									{Key: "key-field", Path: "key-path"},
+								},
+							},
+						},
 					},
 				}
 				return d

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -458,6 +458,29 @@ func Test_NewDeployment(t *testing.T) {
 			},
 		},
 		{
+			name: "with-host-network",
+			nginxFn: func(n v1alpha1.Nginx) v1alpha1.Nginx {
+				n.Spec.PodTemplate.HostNetwork = true
+				return n
+			},
+			deployFn: func(d appv1.Deployment) appv1.Deployment {
+				d.Spec.Template.Spec.HostNetwork = true
+				d.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{
+					{
+						Name:          defaultHTTPPortName,
+						ContainerPort: defaultHTTPHostNetworkPort,
+						Protocol:      corev1.ProtocolTCP,
+					},
+					{
+						Name:          defaultHTTPSPortName,
+						ContainerPort: defaultHTTPSHostNetworkPort,
+						Protocol:      corev1.ProtocolTCP,
+					},
+				}
+				return d
+			},
+		},
+		{
 			name: "with-resources",
 			nginxFn: func(n v1alpha1.Nginx) v1alpha1.Nginx {
 				n.Spec.Resources = corev1.ResourceRequirements{


### PR DESCRIPTION
This change adds support to `HostNetwork` on Nginx. With this, the operator creates the Nginx pods with `pod.spec.hostNetwork` option enabled. With hostNetwork enabled, the pod will use ports `80` and `443` instead of `8080` and `8443`.