### PR TITLE
Set security context for nginx container only

### DIFF
--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -48,6 +48,9 @@ type NginxSpec struct {
 	// Cache allows configuring a cache volume for nginx to use.
 	// +optional
 	Cache NginxCacheSpec `json:"cache,omitempty"`
+	// SecurityContext configures security attributes for the nginx container.
+	// +optional
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 }
 
 type NginxCacheSpec struct {
@@ -73,10 +76,6 @@ type NginxPodTemplateSpec struct {
 	// HostNetwork enabled causes the pod to use the host's network namespace.
 	// +optional
 	HostNetwork bool `json:"hostNetwork,omitempty"`
-
-	// SecurityContext configures pod-level security attributes.
-	// +optional
-	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 }
 
 // NginxStatus defines the observed state of Nginx

--- a/pkg/apis/nginx/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/nginx/v1alpha1/zz_generated.deepcopy.go
@@ -156,11 +156,6 @@ func (in *NginxPodTemplateSpec) DeepCopyInto(out *NginxPodTemplateSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.SecurityContext != nil {
-		in, out := &in.SecurityContext, &out.SecurityContext
-		*out = new(v1.PodSecurityContext)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 
@@ -235,6 +230,11 @@ func (in *NginxSpec) DeepCopyInto(out *NginxSpec) {
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	in.Cache.DeepCopyInto(&out.Cache)
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(v1.SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -110,10 +110,11 @@ func NewDeployment(n *v1alpha1.Nginx) (*appv1.Deployment, error) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:      "nginx",
-							Image:     n.Spec.Image,
-							Command:   nginxEntrypoint,
-							Resources: n.Spec.Resources,
+							Name:            "nginx",
+							Image:           n.Spec.Image,
+							Command:         nginxEntrypoint,
+							Resources:       n.Spec.Resources,
+							SecurityContext: n.Spec.SecurityContext,
 							ReadinessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -137,9 +138,8 @@ func NewDeployment(n *v1alpha1.Nginx) (*appv1.Deployment, error) {
 							Resources: healthcheckResources,
 						},
 					},
-					Affinity:        n.Spec.PodTemplate.Affinity,
-					HostNetwork:     n.Spec.PodTemplate.HostNetwork,
-					SecurityContext: n.Spec.PodTemplate.SecurityContext,
+					Affinity:    n.Spec.PodTemplate.Affinity,
+					HostNetwork: n.Spec.PodTemplate.HostNetwork,
 				},
 			},
 		},

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -556,14 +556,14 @@ func Test_NewDeployment(t *testing.T) {
 		{
 			name: "with-security-context",
 			nginxFn: func(n v1alpha1.Nginx) v1alpha1.Nginx {
-				n.Spec.PodTemplate.SecurityContext = &corev1.PodSecurityContext{
+				n.Spec.SecurityContext = &corev1.SecurityContext{
 					RunAsUser:  new(int64),
 					RunAsGroup: new(int64),
 				}
 				return n
 			},
 			deployFn: func(d appv1.Deployment) appv1.Deployment {
-				d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				d.Spec.Template.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
 					RunAsUser:  new(int64),
 					RunAsGroup: new(int64),
 				}


### PR DESCRIPTION
Instead of setting the security context to the pod, it makes sense to apply it only to the nginx container. The sidecar container is internal and the user should not be able to change its security parameters.