### PR TITLE
feat: add hostIP in nginx status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	cloud.google.com/go v0.43.0 // indirect
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
-	github.com/go-openapi/spec v0.19.0
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/googleapis/gnostic v0.3.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
@@ -25,7 +24,7 @@ require (
 	k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/klog v0.3.3 // indirect
-	k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6
+	k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6 // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
 )
 

--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -107,6 +107,8 @@ type PodStatus struct {
 	Name string `json:"name"`
 	// PodIP is the IP if the POD
 	PodIP string `json:"podIP"`
+	// HostIP is the IP where POD is running
+	HostIP string `json:"hostIP"`
 }
 
 type ServiceStatus struct {

--- a/pkg/controller/nginx/nginx_controller.go
+++ b/pkg/controller/nginx/nginx_controller.go
@@ -217,10 +217,10 @@ func (r *ReconcileNginx) refreshStatus(ctx context.Context, nginx *nginxv1alpha1
 	if err != nil {
 		return fmt.Errorf("failed to list pods for nginx: %v", err)
 	}
-
 	services, err := listServices(ctx, r.client, nginx)
 	if err != nil {
 		return fmt.Errorf("failed to list services for nginx: %v", err)
+
 	}
 
 	sort.Slice(nginx.Status.Pods, func(i, j int) bool {
@@ -236,7 +236,6 @@ func (r *ReconcileNginx) refreshStatus(ctx context.Context, nginx *nginxv1alpha1
 		nginx.Status.Services = services
 		nginx.Status.CurrentReplicas = int32(len(pods))
 		nginx.Status.PodSelector = k8s.LabelsForNginxString(nginx.Name)
-
 		err := r.client.Status().Update(ctx, nginx)
 		if err != nil {
 			return fmt.Errorf("failed to update nginx status: %v", err)
@@ -257,13 +256,20 @@ func listPods(ctx context.Context, c client.Client, nginx *nginxv1alpha1.Nginx) 
 	}
 
 	var pods []nginxv1alpha1.PodStatus
+
 	for _, p := range podList.Items {
 		if p.Status.PodIP == "" {
 			p.Status.PodIP = "<pending>"
 		}
+
+		if p.Status.HostIP == "" {
+			p.Status.HostIP = "<pending>"
+		}
+
 		pods = append(pods, nginxv1alpha1.PodStatus{
-			Name:  p.Name,
-			PodIP: p.Status.PodIP,
+			Name:   p.Name,
+			PodIP:  p.Status.PodIP,
+			HostIP: p.Status.HostIP,
 		})
 	}
 	sort.Slice(pods, func(i, j int) bool {


### PR DESCRIPTION
Add hostIP in nginx status.

```sh
$ kubectl get nginxes.nginx.tsuru.io -o jsonpath='{.items[*].status.pods}'
[map[hostIP:10.1.0.4 name:nginx-with-configmap-c8cd5c9d4-8c5zt podIP:10.1.0.20] map[hostIP:10.1.0.35 name:nginx-with-configmap-c8cd5c9d4-mqt5n podIP:10.1.0.39] map[name:nginx-with-configmap-c8cd5c9d4-qkdt9 podIP:10.1.0.80 hostIP:10.1.0.66]]
````
Closes #22 