### PR TITLE
feat: allow to change external traffic policy and disable pod selector

### DIFF
--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -129,6 +129,11 @@ type NginxService struct {
 	// Annotations are extra annotations for the service.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// ExternalTrafficPolicy defines whether external traffic will be routed to
+	// node-local or cluster-wide endpoints. Defaults to the default Service
+	// externalTrafficPolicy value.
+	// +optional
+	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
 }
 
 // ConfigRef is a reference to a config object.

--- a/pkg/apis/nginx/v1alpha1/nginx_types.go
+++ b/pkg/apis/nginx/v1alpha1/nginx_types.go
@@ -134,6 +134,10 @@ type NginxService struct {
 	// externalTrafficPolicy value.
 	// +optional
 	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicyType `json:"externalTrafficPolicy,omitempty"`
+	// UsePodSelector defines whether Service should automatically map the
+	// endpoints using the pod's label selector. Defaults to true.
+	// +optional
+	UsePodSelector *bool `json:"usePodSelector,omitempty"`
 }
 
 // ConfigRef is a reference to a config object.

--- a/pkg/apis/nginx/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/nginx/v1alpha1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *NginxService) DeepCopyInto(out *NginxService) {
 			(*out)[key] = val
 		}
 	}
+	if in.UsePodSelector != nil {
+		in, out := &in.UsePodSelector, &out.UsePodSelector
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -173,11 +173,15 @@ func NewService(n *v1alpha1.Nginx) *corev1.Service {
 	var labels, annotations map[string]string
 	var lbIP string
 	var externalTrafficPolicy corev1.ServiceExternalTrafficPolicyType
+	labelSelector := LabelsForNginx(n.Name)
 	if n.Spec.Service != nil {
 		labels = n.Spec.Service.Labels
 		annotations = n.Spec.Service.Annotations
 		lbIP = n.Spec.Service.LoadBalancerIP
 		externalTrafficPolicy = n.Spec.Service.ExternalTrafficPolicy
+		if n.Spec.Service.UsePodSelector != nil && !*n.Spec.Service.UsePodSelector {
+			labelSelector = nil
+		}
 	}
 	service := corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -212,7 +216,7 @@ func NewService(n *v1alpha1.Nginx) *corev1.Service {
 					Port:       int32(443),
 				},
 			},
-			Selector:              LabelsForNginx(n.Name),
+			Selector:              labelSelector,
 			LoadBalancerIP:        lbIP,
 			Type:                  nginxService(n),
 			ExternalTrafficPolicy: externalTrafficPolicy,

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -172,10 +172,12 @@ func mergeMap(a, b map[string]string) map[string]string {
 func NewService(n *v1alpha1.Nginx) *corev1.Service {
 	var labels, annotations map[string]string
 	var lbIP string
+	var externalTrafficPolicy corev1.ServiceExternalTrafficPolicyType
 	if n.Spec.Service != nil {
 		labels = n.Spec.Service.Labels
 		annotations = n.Spec.Service.Annotations
 		lbIP = n.Spec.Service.LoadBalancerIP
+		externalTrafficPolicy = n.Spec.Service.ExternalTrafficPolicy
 	}
 	service := corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -210,9 +212,10 @@ func NewService(n *v1alpha1.Nginx) *corev1.Service {
 					Port:       int32(443),
 				},
 			},
-			Selector:       LabelsForNginx(n.Name),
-			LoadBalancerIP: lbIP,
-			Type:           nginxService(n),
+			Selector:              LabelsForNginx(n.Name),
+			LoadBalancerIP:        lbIP,
+			Type:                  nginxService(n),
+			ExternalTrafficPolicy: externalTrafficPolicy,
 		},
 	}
 	return &service

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -1057,6 +1057,51 @@ func TestNewService(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "using Local externalTrafficPolicy",
+			nginx: func() v1alpha1.Nginx {
+				n := nginxWithService()
+				n.Spec.Service.Type = corev1.ServiceTypeLoadBalancer
+				n.Spec.Service.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+				return n
+			}(),
+			want: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-nginx-service",
+					Namespace: "default",
+					Labels: map[string]string{
+						"nginx.tsuru.io/resource-name": "my-nginx",
+						"nginx.tsuru.io/app":           "nginx",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("http"),
+							Port:       int32(80),
+						},
+						{
+							Name:       "https",
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("https"),
+							Port:       int32(443),
+						},
+					},
+					Selector: map[string]string{
+						"nginx.tsuru.io/resource-name": "my-nginx",
+						"nginx.tsuru.io/app":           "nginx",
+					},
+					Type:                  corev1.ServiceTypeLoadBalancer,
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -1102,6 +1102,45 @@ func TestNewService(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "without pod selector",
+			nginx: func() v1alpha1.Nginx {
+				n := nginxWithService()
+				n.Spec.Service.UsePodSelector = func(b bool) *bool { return &b }(false)
+				return n
+			}(),
+			want: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-nginx-service",
+					Namespace: "default",
+					Labels: map[string]string{
+						"nginx.tsuru.io/resource-name": "my-nginx",
+						"nginx.tsuru.io/app":           "nginx",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("http"),
+							Port:       int32(80),
+						},
+						{
+							Name:       "https",
+							Protocol:   corev1.ProtocolTCP,
+							TargetPort: intstr.FromString("https"),
+							Port:       int32(443),
+						},
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When running the Nginx resources into a live cluster may be required to change the external traffic policy and map the endpoints manually to overcome some internal cloud limitations.