### PR TITLE
fix: adds some extra size to the cache volume

### DIFF
--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -883,14 +883,13 @@ func Test_NewDeployment(t *testing.T) {
 					Name:      "cache-vol",
 					MountPath: "/var/cache",
 				})
-				q, err := resource.ParseQuantity("10Mi")
-				require.NoError(t, err)
+				q := resource.NewQuantity(int64(11010048), resource.BinarySI)
 				d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, corev1.Volume{
 					Name: "cache-vol",
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							Medium:    "Memory",
-							SizeLimit: &q,
+							SizeLimit: q,
 						},
 					},
 				})


### PR DESCRIPTION
The cache manager allows the cache size to be greater than the limit set by the cache_size directive. If this value is set, we should add some extra space to avoid pod evictions when this happens. 

This PR adds extra 5% of space to the cache volume to avoid pod evictions.